### PR TITLE
Corrected the field name for BTC transaction table in CF template

### DIFF
--- a/analytics/consumer/aws-public-blockchain.yaml
+++ b/analytics/consumer/aws-public-blockchain.yaml
@@ -178,7 +178,7 @@ Resources:
             - Name: fee
               Type: double
             - Name: inputs
-              Type: array<struct<index:bigint,spent_transaction_hash:string,spend_output_index:bigint,script_asm:string,script_hex:string,sequence:bigint,required_signatures:bigint,type:string,address:string,value:double>>
+              Type: array<struct<index:bigint,spent_transaction_hash:string,spent_output_index:bigint,script_asm:string,script_hex:string,sequence:bigint,required_signatures:bigint,type:string,address:string,value:double>>
             - Name: outputs
               Type: array<struct<index:bigint,script_asm:string,script_hex:string,required_signatures:bigint,type:string,address:string,value:double>>
           InputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat

--- a/analytics/consumer/schema/btc.md
+++ b/analytics/consumer/schema/btc.md
@@ -55,7 +55,7 @@ fee | | double | The fee paid by this transaction
 inputs | | array | Transaction inputs
 inputs | index | bigint | 0 indexed number of an input within a transaction
 inputs | spent_transaction_hash | string | The hash of the transaction which contains the output that this input spends
-inputs | spend_output_index | bigint | The index of the output this input spends
+inputs | spent_output_index | bigint | The index of the output this input spends
 inputs | script_asm | string | Symbolic representation of the bitcoins script language op-codes
 inputs | script_hex | string | Hexadecimal representation of the bitcoins script language op-codes
 inputs | sequence | bigint | A number intended to allow unconfirmed time-locked transactions to be updated before being finalized; not currently used except to disable locktime in a transaction
@@ -78,7 +78,7 @@ View for all inputs can be created from table transactions with the following st
 
 ```sql
 CREATE OR REPLACE VIEW btc.inputs AS (
-  SELECT t.date,t.block_hash,t.block_number,t.block_timestamp,t.hash AS transaction_hash,input.index,input.spent_transaction_hash,input.spend_output_index,input.script_asm,input.script_hex,input.sequence,input.required_signatures,input.type,input.address,input.value FROM btc.transactions t,UNNEST(t.inputs) AS t(input)
+  SELECT t.date,t.block_hash,t.block_number,t.block_timestamp,t.hash AS transaction_hash,input.index,input.spent_transaction_hash,input.spent_output_index,input.script_asm,input.script_hex,input.sequence,input.required_signatures,input.type,input.address,input.value FROM btc.transactions t,UNNEST(t.inputs) AS t(input)
 )
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-solutions-library-samples/guidance-for-digital-assets-on-aws/issues/7

*Description of changes:*

The below CF template contains the schema for the BTC transaction table. As per the template, the field "input" in the transaction table contains "spend_output_index".

[guidance-for-digital-assets-on-aws/analytics/consumer/aws-public-blockchain.yaml](https://github.com/aws-solutions-library-samples/guidance-for-digital-assets-on-aws/blob/fd2310503135df6210c4134b50b8a2cccaf0d8e7/analytics/consumer/aws-public-blockchain.yaml#L181)

Line 181 in [fd23105](https://github.com/aws-solutions-library-samples/guidance-for-digital-assets-on-aws/commit/fd2310503135df6210c4134b50b8a2cccaf0d8e7)

 Type: array<struct<index:bigint,spent_transaction_hash:string,spend_output_index:bigint,script_asm:string,script_hex:string,sequence:bigint,required_signatures:bigint,type:string,address:string,value:double>> 
When checking the source data in the S3 bucket, it can be seen that the name of the field is "spent_output_index" (not "spend_output_index").

S3 bucket URI for transaction table: s3://aws-public-blockchain/v1.0/btc/transactions/

It can also be verified in the below code section:

https://github.com/aws-solutions-library-samples/guidance-for-digital-assets-on-aws/blob/fd2310503135df6210c4134b50b8a2cccaf0d8e7/analytics/producer/copilot/bitcoin-worker/worker.py#L331C1-L333C32

I have verified the same by updating the template and testing in my AWS account. I am getting the desired result after updating the above mentioned line in the CloudFormation template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
